### PR TITLE
fix_for_poetry_version

### DIFF
--- a/fastapi_template/__init__.py
+++ b/fastapi_template/__init__.py
@@ -1,1 +1,13 @@
-__version__ = "0.1.0"
+from pathlib import Path
+
+import toml
+
+
+def get_version() -> str:
+    path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject = toml.loads(open(str(path)).read())
+    version: str = pyproject["tool"]["poetry"]["version"]
+    return version
+
+
+__version__ = get_version()

--- a/poetry.lock
+++ b/poetry.lock
@@ -698,7 +698,7 @@ selenium = ["selenium"]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -714,7 +714,7 @@ python-versions = ">=3.7"
 name = "types-requests"
 version = "2.28.8"
 description = "Typing stubs for requests"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -722,10 +722,18 @@ python-versions = "*"
 types-urllib3 = "<1.27"
 
 [[package]]
+name = "types-toml"
+version = "0.10.8"
+description = "Typing stubs for toml"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "types-urllib3"
 version = "1.26.22"
 description = "Typing stubs for urllib3"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -857,7 +865,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "5ead28b0c6b2ddd82528f5b5946f082baf7fc85dbc240a9d16ca38b51904be73"
+content-hash = "bbe0a0fbf1ec4577310ad1db3e772163c803827fdbad25c7624c1da01b8dee5b"
 
 [metadata.files]
 anyio = [
@@ -1309,6 +1317,10 @@ tomli = [
 types-requests = [
     {file = "types-requests-2.28.8.tar.gz", hash = "sha256:7a9f7b152d594a1c18dd4932cdd2596b8efbeedfd73caa4e4abb3755805b4685"},
     {file = "types_requests-2.28.8-py3-none-any.whl", hash = "sha256:b0421f9f2d0dd0f8df2c75f974686517ca67473f05b466232d4c6384d765ad7a"},
+]
+types-toml = [
+    {file = "types-toml-0.10.8.tar.gz", hash = "sha256:b7e7ea572308b1030dc86c3ba825c5210814c2825612ec679eb7814f8dd9295a"},
+    {file = "types_toml-0.10.8-py3-none-any.whl", hash = "sha256:8300fd093e5829eb9c1fba69cee38130347d4b74ddf32d0a7df650ae55c2b599"},
 ]
 types-urllib3 = [
     {file = "types-urllib3-1.26.22.tar.gz", hash = "sha256:b05af90e73889e688094008a97ca95788db8bf3736e2776fd43fb6b171485d94"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ authors = ["unruffled-nightingale <unruffled.nightingale@gmail.com>"]
 python = "^3.9"
 fastapi = "~0.79"
 requests = "~2"
-types-requests = "~2"
 uvicorn = { extras = ["standard"], version = "~0.18" }
+toml = "~0.10"
 
 [tool.poetry.dev-dependencies]
 bandit = "*"
@@ -24,6 +24,8 @@ pytest = "*"
 pytest-cov = "*"
 pytest-randomly = "*"
 testcontainers = "~3.6"
+types-requests = "~2"
+types-toml = "~0.10"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
# Description of change

Added a fix for poetry version to ensure that version in fastapi.init.py is calculated based on the value in pyproject.toml. This is due to poetry update not updating version in fastapi.init.py (see https://github.com/python-poetry/poetry/issues/144)

## Issue ticket number and link

N/A


