### PR TITLE
Simplified docker build by moving to makefile

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -1,12 +1,9 @@
-name: publish docker on main or release
+name: publish docker on main
 
 on:
   push:
     branches:
       - main
-    tags:
-      - v*
-
 env:
   IMAGE_NAME: fastapi_template
 
@@ -16,22 +13,5 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v3
-      - run: docker build . --file Dockerfile --tag $IMAGE_NAME
       - run: echo "${{ secrets.CONTAINER_REGISTRY_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-      - run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
-
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+      - run: make push-docker

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-NAME=fastapi_template
-
 install:
 	poetry install
 
@@ -49,10 +47,17 @@ format:
 	poetry run trailing-whitespace-fixer
 
 docker-build:
-	docker build -t $(NAME):latest .
+	docker build -t fastapi_template .
 
 docker-run: docker-build
-	docker run -p 8000:8000 -d $(NAME):latest
+	docker run -p 8000:8000 -d fastapi_template
+
+docker-stop:
+	docker stop $(shell docker ps -aqf "ancestor=fastapi_template")
+
+docker-push: docker-build
+    docker tag fastapi_template ghcr.io/unruffled-nightingale/fastapi_template:latest
+	docker push ghcr.io/unruffled-nightingale/fastapi_template:latest
 
 kube-apply:
 	kubectl apply -f .kube/service.yml

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docker-stop:
 	docker stop $(shell docker ps -aqf "ancestor=fastapi_template")
 
 docker-push: docker-build
-    docker tag fastapi_template ghcr.io/unruffled-nightingale/fastapi_template:latest
+	docker tag fastapi_template ghcr.io/unruffled-nightingale/fastapi_template:latest
 	docker push ghcr.io/unruffled-nightingale/fastapi_template:latest
 
 kube-apply:


### PR DESCRIPTION
# Description of change

The Github action for building and deploying the docker image contained its own logic. To allow users to run this locally this logic was moved to the Makefile and then referenced in the Github action to avoid repetition. 

Building docker image on release was also removed. 

## Issue ticket number and link

N/A

